### PR TITLE
fix: Correct Brave browser class name in windowrules.conf

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -11,7 +11,7 @@ $&=override
 # idleinhibit rules
 windowrule = idleinhibit fullscreen, class:^(.*celluloid.*)$|^(.*mpv.*)$|^(.*vlc.*)$
 windowrule = idleinhibit fullscreen, class:^(.*[Ss]potify.*)$
-windowrule = idleinhibit fullscreen, class:^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*Brave.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
+windowrule = idleinhibit fullscreen, class:^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
 
 # Picture-in-Picture
 windowrule = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$

--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -22,7 +22,7 @@ windowrule = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 windowrule = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
 
 windowrule = opacity 0.90 $& 0.90 $& 1,class:^(firefox)$
-windowrule = opacity 0.90 $& 0.90 $& 1,class:^(Brave-browser)$
+windowrule = opacity 0.90 $& 0.90 $& 1,class:^(brave-browser)$
 windowrule = opacity 0.80 $& 0.80 $& 1,class:^(code-oss)$
 windowrule = opacity 0.80 $& 0.80 $& 1,class:^([Cc]ode)$
 windowrule = opacity 0.80 $& 0.80 $& 1,class:^(code-url-handler)$


### PR DESCRIPTION
# Pull Request

## Description

This pull request corrects a typo in the window rule for the Brave browser within the `windowrules.conf` file. The class name was previously `Brave`, which is incorrect. This has been changed to `brave-browser` to ensure that the window rules are applied correctly to the Brave browser.

This fixes an issue where opacity and idle-inhibit rules were not being applied to Brave browser windows.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
